### PR TITLE
Next patch release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,7 @@
   - [v1.2.1](#v121)
 - [v1.3](#v13)
   - [v1.3.1](#v131)
+  - [v1.3.1](#v131-1)
 
 
 ## v1.1
@@ -54,3 +55,6 @@ Below are listed the exposed portions of the API as of the first release.
  
 ### v1.3.1
 - `runTestDir()` prints curent version.
+- 
+### v1.3.1
+- Fixed breaking issue: `expect.falsey` had been removed in previous release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oliver-test",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Lightweight library for testing javascript and typescript",
   "main": "index.js",
   "types": "src/types.d.ts",

--- a/src/Assertions.js
+++ b/src/Assertions.js
@@ -128,6 +128,19 @@ module.exports = {
         genericAssertIdentity(assert,actual,"Expected value to be truthy, but it was not.")
     },
     
+    
+    /**
+     * Checks that a value is falsey
+     * @param actual 
+     */
+    falsey(actual) {
+        let assert = function() {
+            if (!actual) return true;
+            else return false;
+        }
+        genericAssertIdentity(assert,actual,"Expected value to be falsey, but it was not.")
+    },
+    
 
     /**
      * Checks that `operation` throws an error of type `errorClass`


### PR DESCRIPTION
fixed breaking issue: `expect.falsey` had been removed in previous release